### PR TITLE
Fixes Issue #14, see description below

### DIFF
--- a/cdavurls.php
+++ b/cdavurls.php
@@ -131,15 +131,15 @@ elseif($type=='ICS')
 		{
 			echo '<h4>'.$row['firstname'].' '.$row['lastname'].' :</h4>';
 			
-			echo "<PRE>".$langs->trans('Full')." :\n".dol_buildpath('cdav/ics.php', 2).'?token='.base64url_encode(mcrypt_ecb(MCRYPT_BLOWFISH, CDAV_URI_KEY, $row['rowid'].'+ø+full', MCRYPT_ENCRYPT))."\n\n";
-			echo $langs->trans('NoLabel')." :\n".dol_buildpath('cdav/ics.php', 2).'?token='.base64url_encode(mcrypt_ecb(MCRYPT_BLOWFISH, CDAV_URI_KEY, $row['rowid'].'+ø+nolabel', MCRYPT_ENCRYPT)).'</PRE><br/>';
+			echo "<PRE>".$langs->trans('Full')." :\n".dol_buildpath('cdav/ics.php', 2).'?token='.base64url_encode(mcrypt_encrypt (MCRYPT_BLOWFISH, CDAV_URI_KEY, $row['rowid'].'+ø+full', ecb))."\n\n";
+			echo $langs->trans('NoLabel')." :\n".dol_buildpath('cdav/ics.php', 2).'?token='.base64url_encode(mcrypt_encrypt (MCRYPT_BLOWFISH, CDAV_URI_KEY, $row['rowid'].'+ø+nolabel', ecb)).'</PRE><br/>';
 			
 		}
 	}
 	else
 	{
-		echo "<PRE>".$langs->trans('Full')." :\n".dol_buildpath('cdav/ics.php', 2).'?token='.base64url_encode(mcrypt_ecb(MCRYPT_BLOWFISH, CDAV_URI_KEY, $user->id.'+ø+full', MCRYPT_ENCRYPT))."\n\n";
-		echo $langs->trans('NoLabel')." :\n".dol_buildpath('cdav/ics.php', 2).'?token='.base64url_encode(mcrypt_ecb(MCRYPT_BLOWFISH, CDAV_URI_KEY, $user->id.'+ø+nolabel', MCRYPT_ENCRYPT)).'</PRE><br/>';
+		echo "<PRE>".$langs->trans('Full')." :\n".dol_buildpath('cdav/ics.php', 2).'?token='.base64url_encode(mcrypt_encrypt (MCRYPT_BLOWFISH, CDAV_URI_KEY, $user->id.'+ø+full', ecb))."\n\n";
+		echo $langs->trans('NoLabel')." :\n".dol_buildpath('cdav/ics.php', 2).'?token='.base64url_encode(mcrypt_encrypt (MCRYPT_BLOWFISH, CDAV_URI_KEY, $user->id.'+ø+nolabel', ecb)).'</PRE><br/>';
 	}
 
 }


### PR DESCRIPTION
See Issue: https://github.com/Befox/cdav/issues/14
mcrypt_ecb() DEPRECATED in PHP 5.5.0, and REMOVED in PHP 7.0.0. #14

Fatal error: Uncaught Error: Call to undefined function mcrypt_ecb() in /htdocs/cdav/cdavurls.php:134 Stack trace: #0 {main} thrown in /htdocs/cdav/cdavurls.php on line 134

php.net (http://php.net/manual/de/function.mcrypt-ecb.php) says:

This function was DEPRECATED in PHP 5.5.0, and REMOVED in PHP 7.0.0.
Alternatives to this function include:
mcrypt_decrypt()
mcrypt_encrypt()