### PR TITLE
401 unauthorized with correct user credentials and PHP-FPM

### DIFF
--- a/.htaccess
+++ b/.htaccess
@@ -1,4 +1,5 @@
 ## HTTP Auth workaround for php in fastcgi mode
+SetEnvIf Authorization "(.*)" HTTP_AUTHORIZATION=$1
 <IfModule mod_fastcgi.c>
 	<IfModule mod_rewrite.c>
 		RewriteEngine on


### PR DESCRIPTION
SetEnvIf Authorization "(.*)" HTTP_AUTHORIZATION=$1
fixes User Authentification Issue wit PHP-FPM
See https://devhacksandgoodies.wordpress.com/2014/06/27/apache-pass-authorization-header-to-phps-_serverhttp_authorization/ for further information.

the added line (2) would do the job. line 1 and 3 to 13 could be deleted.