### PR TITLE
Remove METHOD property in Caldav objects

### DIFF
--- a/ics.php
+++ b/ics.php
@@ -155,7 +155,6 @@ $arrEvents = $cdavLib->getFullCalendarObjects($id, true);
 
 echo "BEGIN:VCALENDAR\n";
 echo "VERSION:2.0\n";
-echo "METHOD:PUBLISH\n";
 echo "PRODID:-//Dolibarr CDav//FR\n";
 foreach($arrEvents as $event)
 {

--- a/lib/cdav.lib.php
+++ b/lib/cdav.lib.php
@@ -220,7 +220,6 @@ class CdavLib
 			{
 				$caldata ="BEGIN:VCALENDAR\n";
 				$caldata.="VERSION:2.0\n";
-				$caldata.="METHOD:PUBLISH\n";
 				$caldata.="PRODID:-//Dolibarr CDav//FR\n";
 			}
 			$caldata.="BEGIN:".$type."\n";
@@ -329,7 +328,6 @@ class CdavLib
 
 			$caldata ="BEGIN:VCALENDAR\n";
 			$caldata.="VERSION:2.0\n";
-			$caldata.="METHOD:PUBLISH\n";
 			$caldata.="PRODID:-//Dolibarr CDav//FR\n";
 			$caldata.="BEGIN:".$type."\n";
 			$caldata.="CREATED:".gmdate('Ymd\THis', strtotime($obj->datec))."Z\n";


### PR DESCRIPTION
This is a choice from SabreDAV (cf : `lib/SabreDAV/vendor/sabre/vobject/lib/Component/VCalendar.php:503:                    'message' => 'A calendar object on a CalDAV server MUST NOT have a METHOD property.'`

This occurs to synchronization errors with clients such as Nextcloud using `vdirsyncer`

Let me know your point of view on this subject please
And a huge thanks for your work as open / free software !