### PR TITLE
FIX: use sabre/dav instance from Dolibarr

### DIFF
--- a/server.php
+++ b/server.php
@@ -178,7 +178,7 @@ use Sabre\DAV;
 use Sabre\DAVACL;
 
 // The autoloader
-require './lib/SabreDAV/vendor/autoload.php';
+require DOL_DOCUMENT_ROOT.'/includes/sabre/autoload.php';
 require './class/PrincipalsDolibarr.php';
 require './class/CardDAVDolibarr.php';
 require './class/CalDAVDolibarr.php';


### PR DESCRIPTION
Hi,

One way to fix issue #53 is to use the Sabre/DAV library from Dolibarr. I quickly tested the CardDAV sync and it seems to work.

@jpfox Does the module use some of the newer APIs of Sabre/DAV or is the old Dolibarr version enough ? I would strongly advise to test thouroughly that everything works before merging this PR anyway.

Greetings.

---

Bonjour,

Une manière de résoudre l'issue #53 est d'utiliser la bibliothèque Sabre/DAV de Dolibarr. J'ai testé rapidement la synchro CardDAV et ça semble fonctionner.

@jpfox Est-ce que le module utilise des APIs récentes de Sabre/DAV ou bien la version de Dolibarr est-elle suffisante ? Quoi qu'il en soit, je vous recommanderais fortement de tester en profondeur que tout fonctionne bien avant de merger cette PR.