### PR TITLE
fix: correct hasRigh to hasRight typo in CardDAVDolibarr.php

### DIFF
--- a/class/CardDAVDolibarr.php
+++ b/class/CardDAVDolibarr.php
@@ -1711,7 +1711,7 @@ class Dolibarr extends AbstractBackend implements SyncSupport {
 			$this->db->query($sql);
 		}
 
-		if(CDAV_MEMBER_SYNC>0 && intval($addressbookId)>=(2*CDAV_ADDRESSBOOK_ID_SHIFT) && intval($addressbookId)<(3*CDAV_ADDRESSBOOK_ID_SHIFT) && $this->user->hasRigh('adherent','creer'))
+		if(CDAV_MEMBER_SYNC>0 && intval($addressbookId)>=(2*CDAV_ADDRESSBOOK_ID_SHIFT) && intval($addressbookId)<(3*CDAV_ADDRESSBOOK_ID_SHIFT) && $this->user->hasRight('adherent','creer'))
 		{
 			$rdata = $this->_parseDataMember($cardData, 'U');
 


### PR DESCRIPTION
Hi @Befox 👋

Just a small typo fix — `hasRigh` → `hasRight` on line 1714 of `class/CardDAVDolibarr.php`.

The method `User::hasRigh()` doesn't exist, so this was causing a PHP fatal error. Happy to address any feedback!